### PR TITLE
Fix duplicate variable declaration in Chrome extension

### DIFF
--- a/content-utils-browser.js
+++ b/content-utils-browser.js
@@ -11,6 +11,12 @@
  * When loaded as an ES6 module (in tests), functions are exported.
  */
 
+// Guard against multiple injections - if already loaded, skip re-initialization
+if (typeof window !== 'undefined' && window.PROCESSED_MARKER) {
+  // Already loaded, exit early
+  console.log("content-utils-browser.js already loaded, skipping re-initialization");
+} else {
+
 /**
  * Marker attribute for processed elements
  */
@@ -239,3 +245,5 @@ if (typeof window !== 'undefined') {
   window.getUsername = getUsername;
   window.updateTextNodes = updateTextNodes;
 }
+
+} // End of guard against multiple injections


### PR DESCRIPTION
Added a guard to prevent re-initialization when the script is injected multiple times into the same page context. This fixes the "Uncaught SyntaxError: Identifier 'PROCESSED_MARKER' has already been declared" error that occurred when tabs were updated or the extension button was clicked multiple times.

The guard checks if PROCESSED_MARKER is already defined on the window object before running the initialization code, preventing const re-declaration errors.