### PR TITLE
Fix Code Owner setting not saving

### DIFF
--- a/options.js
+++ b/options.js
@@ -332,7 +332,7 @@ document.addEventListener('DOMContentLoaded', () => {
         }
         const settings = result.githubUnveilerSettings || {};
         parseDisplayNameFormatCheckbox.checked = settings.parseDisplayNameFormat || false;
-        replaceCodeOwnerMergingIsBlockedCheckbox.checked = settings.replaceCodeOwnerMergingIsBlockedCheckbox || false;
+        replaceCodeOwnerMergingIsBlockedCheckbox.checked = settings.replaceCodeOwnerMergingIsBlocked || false;
       });
     } else {
       console.warn('chrome.storage API not available.');

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,7 +4,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "github-unveiler",
       "devDependencies": {
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^30.0.2"


### PR DESCRIPTION
The Code Owner setting wasn't correctly loading because of a property name mismatch. The save function used 'replaceCodeOwnerMergingIsBlocked' but the load function was trying to read from 'replaceCodeOwnerMergingIsBlockedCheckbox' (with the extra 'Checkbox' suffix).

Fixed by correcting the property name in the loadSettings function to match what is saved and what content.js reads.