### PR TITLE
Fix Chrome Extension origin pattern error

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -30,8 +30,9 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Check PR title
+      env:
+        PR_TITLE: ${{ github.event.pull_request.title }}
       run: |
-        PR_TITLE="${{ github.event.pull_request.title }}"
         echo "PR Title: $PR_TITLE"
 
         # Check if PR title is meaningful (not too short)
@@ -43,9 +44,9 @@ jobs:
         echo "PR title is valid"
 
     - name: Check for description
+      env:
+        PR_BODY: ${{ github.event.pull_request.body }}
       run: |
-        PR_BODY="${{ github.event.pull_request.body }}"
-
         if [ -z "$PR_BODY" ] || [ ${#PR_BODY} -lt 20 ]; then
           echo "Warning: PR description is empty or too short. Consider adding more details."
           echo "This is just a warning and won't fail the check."

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -2,53 +2,51 @@ name: PR Labeler
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, edited, reopened, synchronize]
 
 jobs:
-  label:
-    name: Label PR
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
-
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-
-    - name: Label based on changed files
-      uses: actions/labeler@v5
-      with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
-
   validate-pr:
-    name: Validate PR
     runs-on: ubuntu-latest
-
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
 
-    - name: Check PR title
-      run: |
-        PR_TITLE="${{ github.event.pull_request.title }}"
-        echo "PR Title: $PR_TITLE"
+      - name: Validate PR title and body
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          echo "PR Title: $PR_TITLE"
 
-        # Check if PR title is meaningful (not too short)
-        if [ ${#PR_TITLE} -lt 10 ]; then
-          echo "PR title is too short. Please provide a more descriptive title."
-          exit 1
-        fi
+          # Check if PR title is meaningful (not too short)
+          if [ ${#PR_TITLE} -lt 10 ]; then
+            echo "PR title is too short. Please provide a more descriptive title."
+            exit 1
+          fi
 
-        echo "PR title is valid"
+          echo "PR title is valid"
 
-    - name: Check for description
-      run: |
-        PR_BODY="${{ github.event.pull_request.body }}"
+          # Use quoted expansion to preserve quotes/newlines and avoid word-splitting
+          if [ -z "$PR_BODY" ] || [ ${#PR_BODY} -lt 20 ]; then
+            echo "Warning: PR description is empty or too short. Consider adding more details."
+            echo "This is just a warning and won't fail the check."
+          else
+            echo "PR has a description"
+          fi
 
-        if [ -z "$PR_BODY" ] || [ ${#PR_BODY} -lt 20 ]; then
-          echo "Warning: PR description is empty or too short. Consider adding more details."
-          echo "This is just a warning and won't fail the check."
-        else
-          echo "PR has a description"
-        fi
+      - name: Set outputs for other steps
+        id: pr
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          # Emit multi-line output safely using a heredoc (GITHUB_OUTPUT)
+          echo "pr_title=${PR_TITLE}" >> $GITHUB_OUTPUT
+          echo "pr_body<<'EOF'" >> $GITHUB_OUTPUT
+          printf '%s\n' "$PR_BODY" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Example consumer
+        run: |
+          echo "Got PR title from output: ${{ steps.pr.outputs.pr_title }}"
+          echo "(PR body is available via steps.pr.outputs.pr_body)"

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -43,7 +43,8 @@ jobs:
           # Emit multi-line output safely using a heredoc (GITHUB_OUTPUT)
           echo "pr_title=${PR_TITLE}" >> $GITHUB_OUTPUT
           echo "pr_body<<'EOF'" >> $GITHUB_OUTPUT
-          printf '%s\n' "$PR_BODY" >> $GITHUB_OUTPUT
+          echo "description<<EOF" >> $GITHUB_OUTPUT
+          echo "$PR_BODY" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Example consumer

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -2,19 +2,36 @@ name: PR Labeler
 
 on:
   pull_request:
-    types: [opened, edited, reopened, synchronize]
+    types: [opened, synchronize, reopened]
 
 jobs:
-  validate-pr:
+  label:
+    name: Label PR
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Label based on changed files
+      uses: actions/labeler@v5
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+  validate-pr:
+    name: Validate PR
+    runs-on: ubuntu-latest
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
 
     - name: Check PR title
-      env:
-        PR_TITLE: ${{ github.event.pull_request.title }}
       run: |
+        PR_TITLE="${{ github.event.pull_request.title }}"
         echo "PR Title: $PR_TITLE"
 
         # Check if PR title is meaningful (not too short)
@@ -26,9 +43,9 @@ jobs:
         echo "PR title is valid"
 
     - name: Check for description
-      env:
-        PR_BODY: ${{ github.event.pull_request.body }}
       run: |
+        PR_BODY="${{ github.event.pull_request.body }}"
+
         if [ -z "$PR_BODY" ] || [ ${#PR_BODY} -lt 20 ]; then
           echo "Warning: PR description is empty or too short. Consider adding more details."
           echo "This is just a warning and won't fail the check."

--- a/background.js
+++ b/background.js
@@ -61,6 +61,12 @@ if (typeof chrome !== 'undefined' && chrome.action) {
     return;
   }
 
+  // Only request permissions for http(s) URLs
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    console.log("Skipping permission request for non-web URL:", url.protocol);
+    return;
+  }
+
   const originPattern = `${url.protocol}//${url.hostname}/*`;
   console.log("Requesting permission for", originPattern);
 
@@ -85,6 +91,10 @@ if (typeof chrome !== 'undefined' && chrome.tabs) {
       try {
         url = new URL(tab.url);
       } catch (e) {
+        return;
+      }
+      // Only check permissions for http(s) URLs
+      if (url.protocol !== 'http:' && url.protocol !== 'https:') {
         return;
       }
       const originPattern = `${url.protocol}//${url.hostname}/*`;


### PR DESCRIPTION
Chrome's permissions API only accepts http:// and https:// URLs. When the extension was used on chrome-extension:// or chrome:// pages, it attempted to create invalid origin patterns, causing the error: "Invalid value for origin pattern chrome-extension://.../*: Invalid scheme"

Added protocol validation to skip permission operations for non-web URLs.