### PR TITLE
Add skip debounce feature flag for name replacements

### DIFF
--- a/options.html
+++ b/options.html
@@ -147,7 +147,18 @@
         <div>
           <strong>Code Owner</strong>
           <div style="font-size: 13px; color: #586069; margin-top: 4px;">
-            Applies display names in the “Merging is blocked” message listing code owners that need to approve the PR.
+            Applies display names in the "Merging is blocked" message listing code owners that need to approve the PR.
+          </div>
+        </div>
+      </label>
+    </div>
+    <div style="margin-bottom: 15px;">
+      <label style="display: flex; align-items: center; cursor: pointer;">
+        <input type="checkbox" id="skipDebounceCheckbox" style="margin-right: 10px;">
+        <div>
+          <strong>Skip Debounce</strong>
+          <div style="font-size: 13px; color: #586069; margin-top: 4px;">
+            Apply name replacements immediately without the 200ms debounce delay. This may improve responsiveness but could impact performance on pages with frequent DOM changes.
           </div>
         </div>
       </label>

--- a/options.js
+++ b/options.js
@@ -323,6 +323,11 @@ document.addEventListener('DOMContentLoaded', () => {
       console.error('Error: replaceCodeOwnerMergingIsBlockedCheckbox element not found.');
       return;
     }
+    const skipDebounceCheckbox = document.getElementById('skipDebounceCheckbox');
+    if (!skipDebounceCheckbox) {
+      console.error('Error: skipDebounceCheckbox element not found.');
+      return;
+    }
 
     if (chrome && chrome.storage && chrome.storage.local) {
       chrome.storage.local.get(['githubUnveilerSettings'], result => {
@@ -333,6 +338,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const settings = result.githubUnveilerSettings || {};
         parseDisplayNameFormatCheckbox.checked = settings.parseDisplayNameFormat || false;
         replaceCodeOwnerMergingIsBlockedCheckbox.checked = settings.replaceCodeOwnerMergingIsBlocked || false;
+        skipDebounceCheckbox.checked = settings.skipDebounce || false;
       });
     } else {
       console.warn('chrome.storage API not available.');
@@ -350,11 +356,17 @@ document.addEventListener('DOMContentLoaded', () => {
       console.error('Error: replaceCodeOwnerMergingIsBlockedCheckbox element not found.');
       return;
     }
+    const skipDebounceCheckbox = document.getElementById('skipDebounceCheckbox');
+    if (!skipDebounceCheckbox) {
+      console.error('Error: skipDebounceCheckbox element not found.');
+      return;
+    }
 
     if (chrome && chrome.storage && chrome.storage.local) {
       const settings = {
         parseDisplayNameFormat: parseDisplayNameFormatCheckbox.checked,
-        replaceCodeOwnerMergingIsBlocked: replaceCodeOwnerMergingIsBlockedCheckbox.checked
+        replaceCodeOwnerMergingIsBlocked: replaceCodeOwnerMergingIsBlockedCheckbox.checked,
+        skipDebounce: skipDebounceCheckbox.checked
       };
 
       chrome.storage.local.set({ githubUnveilerSettings: settings }, () => {
@@ -387,6 +399,11 @@ document.addEventListener('DOMContentLoaded', () => {
   const replaceCodeOwnerMergingIsBlockedCheckbox = document.getElementById('replaceCodeOwnerMergingIsBlockedCheckbox');
   if (replaceCodeOwnerMergingIsBlockedCheckbox) {
     replaceCodeOwnerMergingIsBlockedCheckbox.addEventListener('change', saveSettings);
+  }
+
+  const skipDebounceCheckbox = document.getElementById('skipDebounceCheckbox');
+  if (skipDebounceCheckbox) {
+    skipDebounceCheckbox.addEventListener('change', saveSettings);
   }
 
   loadEnabledDomains();


### PR DESCRIPTION
This commit adds a new 'skip debounce' feature flag that allows users to control whether the 200ms debounce logic applies to name replacements or not.

Changes:
- Added skipDebounce checkbox to options.html Settings section
- Updated options.js to load and save the skipDebounce setting
- Modified content.js to check skipDebounce flag and conditionally apply debounce
- Added storage change listener to update skipDebounce in real-time

When skipDebounce is enabled, name replacements are processed immediately without the 200ms delay, which may improve responsiveness but could impact performance on pages with frequent DOM changes.